### PR TITLE
Debug messages breack the program

### DIFF
--- a/mod_storage_multi.lua
+++ b/mod_storage_multi.lua
@@ -40,7 +40,7 @@ function keyval_store:set(username, data)
 		module:log("debug", "%s:%s:set(%q)", tostring(backends[i].get), backends[i]._store, username);
 		ok, err = backend:set(username, data);
 		if not ok then
-			module:log("error", "Error in storage driver %s: %s", backend.name, tostring(err));
+			module:log((policy == "one") and "warn" or "error", "Error in storage driver %s: %s", backend.name, tostring(err));
 		else
 			oks = oks + 1;
 		end

--- a/mod_storage_multi.lua
+++ b/mod_storage_multi.lua
@@ -37,7 +37,7 @@ function keyval_store:set(username, data)
 	local all, one, oks = true, false, 0;
 	for i = 1, #backends do
 		backend = backends[i];
-		module:log("debug", "%s:%s:set(%q)", tostring(backends[i].get), backends[i].store, username);
+		module:log("debug", "%s:%s:set(%q)", tostring(backends[i].get), backends[i]._store, username);
 		ok, err = backend:set(username, data);
 		if not ok then
 			module:log("error", "Error in storage driver %s: %s", backend.name, tostring(err));


### PR DESCRIPTION
At least for me, using multi storage for "sql" and "ldap" (only "one" expected), it generates an error if I use debug logging.
This change makes it work.